### PR TITLE
Remove "--emit_original_quals".

### DIFF
--- a/src/toil_topmed/topmed_cgl_pipeline.py
+++ b/src/toil_topmed/topmed_cgl_pipeline.py
@@ -698,8 +698,8 @@ def bin_quality_scores(job, config, input_bam_id, bam_index_id, bsqr_report_id, 
                        "--disable_indel_quals",
                        "--useOriginalQualities",
                        "-rf", "BadCigar",
-                       "-nct", str(config.cores),
-                       "--emit_original_quals"]
+                       "-nct", str(config.cores)]
+                       # "--emit_original_quals",
                        # "--createOutputBamMD5",
                        # "--addOutputSAMProgramRecord",
     params.extend(optional_params)


### PR DESCRIPTION
As per: https://github.com/CCDG/Pipeline-Standardization/blob/master/PipelineStandard.md

Near the bottom is a bullet point: `Do not retain the original base quality scores (OQ tag).`

I wanted to remove this option in the script itself.  Does this look good to you, Trevor?

Thanks for your time!